### PR TITLE
Add Smithery to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,16 @@ dist/
 wheels/
 *.egg-info/
 .eggs/
+*.so
+MANIFEST
 
 # Virtual environments
 .venv
 venv/
 ENV/
+env/
+.env/
+.python-version
 
 # IDE settings
 .idea/
@@ -21,6 +26,8 @@ ENV/
 .project
 .pydevproject
 .settings/
+*.sublime-project
+*.sublime-workspace
 
 # Testing
 .coverage
@@ -30,19 +37,36 @@ coverage.xml
 .tox/
 nosetests.xml
 htmlcov/
+.hypothesis/
+.coverage.*
 
 # Documentation
 docs/_build/
 site/
+docs/generated/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+*.ipynb
 
 # Environment variables
 .env
 .env.local
 .env*.local
+*.env
 
 # OS-specific files
 .DS_Store
 Thumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+
+# Logs and databases
+*.log
+*.sqlite
+*.db
+
+# Local development
+local_settings.py
+db.sqlite3
+media/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Dataset Viewer Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Dataset Viewer MCP Server
+[![smithery badge](https://smithery.ai/badge/dataset-viewer)](https://smithery.ai/server/dataset-viewer)
 
 An MCP server for interacting with the [Hugging Face Dataset Viewer API](https://huggingface.co/docs/dataset-viewer), providing capabilities to browse and analyze datasets hosted on the Hugging Face Hub.
 
@@ -81,6 +82,14 @@ The server provides the following tools:
      - `auth_token` (optional): For private datasets
 
 ## Installation
+
+### Installing via Smithery
+
+To install dataset-viewer for Claude Desktop automatically via [Smithery](https://smithery.ai/server/dataset-viewer):
+
+```bash
+npx -y @smithery/cli install dataset-viewer --client claude
+```
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -9,31 +9,76 @@ An MCP server for interacting with the [Hugging Face Dataset Viewer API](https:/
 - Uses `dataset://` URI scheme for accessing Hugging Face datasets
 - Supports dataset configurations and splits
 - Provides paginated access to dataset contents
+- Handles authentication for private datasets
+- Supports searching and filtering dataset contents
+- Provides dataset statistics and analysis
 
 ### Tools
 
-The server provides three main tools:
+The server provides the following tools:
 
-1. **list_splits**
-   - Lists available configurations and splits for a dataset
-   - Required parameters:
-     - `dataset_id`: Dataset identifier on Hugging Face Hub (e.g. 'username/dataset-name')
+1. **validate**
+   - Check if a dataset exists and is accessible
+   - Parameters:
+     - `dataset`: Dataset identifier (e.g. 'stanfordnlp/imdb')
+     - `auth_token` (optional): For private datasets
 
-2. **view_dataset**
-   - View paginated contents of a dataset
-   - Required parameters:
-     - `dataset_id`: Dataset identifier on Hugging Face Hub
-     - `config`: Dataset configuration name (e.g. 'default')
-     - `split`: Dataset split name (e.g. 'train', 'test')
-   - Optional parameters:
-     - `page`: Page number (0-based)
+2. **get_info**
+   - Get detailed information about a dataset
+   - Parameters:
+     - `dataset`: Dataset identifier
+     - `auth_token` (optional): For private datasets
 
-3. **get_stats**
-   - Get statistics about a dataset
-   - Required parameters:
-     - `dataset_id`: Dataset identifier on Hugging Face Hub
-     - `config`: Dataset configuration name
-     - `split`: Dataset split name
+3. **get_rows**
+   - Get paginated contents of a dataset
+   - Parameters:
+     - `dataset`: Dataset identifier
+     - `config`: Configuration name
+     - `split`: Split name
+     - `page` (optional): Page number (0-based)
+     - `auth_token` (optional): For private datasets
+
+4. **get_first_rows**
+   - Get first rows from a dataset split
+   - Parameters:
+     - `dataset`: Dataset identifier
+     - `config`: Configuration name
+     - `split`: Split name
+     - `auth_token` (optional): For private datasets
+
+5. **get_statistics**
+   - Get statistics about a dataset split
+   - Parameters:
+     - `dataset`: Dataset identifier
+     - `config`: Configuration name
+     - `split`: Split name
+     - `auth_token` (optional): For private datasets
+
+6. **search_dataset**
+   - Search for text within a dataset
+   - Parameters:
+     - `dataset`: Dataset identifier
+     - `config`: Configuration name
+     - `split`: Split name
+     - `query`: Text to search for
+     - `auth_token` (optional): For private datasets
+
+7. **filter**
+   - Filter rows using SQL-like conditions
+   - Parameters:
+     - `dataset`: Dataset identifier
+     - `config`: Configuration name
+     - `split`: Split name
+     - `where`: SQL WHERE clause (e.g. "score > 0.5")
+     - `orderby` (optional): SQL ORDER BY clause
+     - `page` (optional): Page number (0-based)
+     - `auth_token` (optional): For private datasets
+
+8. **get_parquet**
+   - Download entire dataset in Parquet format
+   - Parameters:
+     - `dataset`: Dataset identifier
+     - `auth_token` (optional): For private datasets
 
 ## Installation
 
@@ -67,6 +112,10 @@ uv add -e .
 
 ## Configuration
 
+### Environment Variables
+
+- `HUGGINGFACE_TOKEN`: Your Hugging Face API token for accessing private datasets
+
 ### Claude Desktop Integration
 
 Add the following to your Claude Desktop config file:
@@ -91,42 +140,51 @@ On MacOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
 
 ## Usage Examples
 
-1. List available splits for a dataset:
+1. Validate a dataset:
 ```json
 {
-  "dataset_id": "cornell-movie-review-data/rotten_tomatoes"
+  "dataset": "stanfordnlp/imdb"
 }
 ```
 
-2. View dataset contents:
+2. Get dataset information:
 ```json
 {
-  "dataset_id": "cornell-movie-review-data/rotten_tomatoes",
-  "config": "default",
+  "dataset": "stanfordnlp/imdb"
+}
+```
+
+3. Search dataset contents:
+```json
+{
+  "dataset": "stanfordnlp/imdb",
+  "config": "plain_text",
   "split": "train",
+  "query": "great movie"
+}
+```
+
+4. Filter and sort rows:
+```json
+{
+  "dataset": "stanfordnlp/imdb",
+  "config": "plain_text",
+  "split": "train",
+  "where": "label = 'positive'",
+  "orderby": "text DESC",
   "page": 0
 }
 ```
 
-3. Get dataset statistics:
+5. Get dataset statistics:
 ```json
 {
-  "dataset_id": "cornell-movie-review-data/rotten_tomatoes",
-  "config": "default",
+  "dataset": "stanfordnlp/imdb",
+  "config": "plain_text",
   "split": "train"
 }
 ```
 
-## Limitations
-
-- Only works with datasets hosted on the Hugging Face Hub
-- Maximum page size of 100 rows when viewing dataset contents
-- Requires dataset name to be in format 'username/dataset-name'
-
-## Contributing
-
-Contributions are welcome! Please feel free to submit a Pull Request.
-
 ## License
 
-[Add appropriate license]
+MIT License - see [LICENSE](LICENSE) for details

--- a/src/dataset_viewer/server.py
+++ b/src/dataset_viewer/server.py
@@ -16,6 +16,9 @@ other sources, you'll need to upload them to Hugging Face first.
 import asyncio
 from typing import Optional
 import httpx
+import os
+import re
+import json
 
 from mcp.server.models import InitializationOptions
 import mcp.types as types
@@ -26,57 +29,136 @@ import mcp.server.stdio
 
 class DatasetViewerAPI:
     """Internal API client for dataset viewer"""
-    def __init__(self, base_url: str = "https://datasets-server.huggingface.co"):
+    def __init__(self, base_url: str = "https://datasets-server.huggingface.co", auth_token: str | None = None):
         self.base_url = base_url.rstrip("/")
-        self.client = httpx.AsyncClient(base_url=self.base_url)
-        
-    def _validate_dataset_id(self, dataset_id: str) -> None:
-        """Validate dataset ID format (username/dataset-name)"""
-        if not dataset_id or "/" not in dataset_id:
-            raise ValueError(
-                "Invalid dataset ID format. Must be 'username/dataset-name', e.g. 'cornell-movie-review-data/rotten_tomatoes'"
-            )
-        
-    async def get_dataset_info(self, dataset_id: str) -> dict:
-        """Get basic information about a dataset"""
-        self._validate_dataset_id(dataset_id)
-        
-        # First check if dataset is valid
-        response = await self.client.get(f"/is-valid", params={"dataset": dataset_id})
-        response.raise_for_status()
-        
-        # Get splits info
-        response = await self.client.get(f"/splits", params={"dataset": dataset_id})
-        response.raise_for_status()
-        return response.json()
-        
-    async def get_dataset_content(self, dataset_id: str, config: str, split: str, page: int = 0) -> dict:
-        """Get paginated content of a dataset"""
-        self._validate_dataset_id(dataset_id)
-        
+        headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else {}
+        self.client = httpx.AsyncClient(base_url=self.base_url, headers=headers)
+
+    async def validate_dataset(self, dataset: str) -> None:
+        """Validate dataset ID format and check if it exists"""
+        # Validate format (username/dataset-name)
+        if not re.match(r"^[^/]+/[^/]+$", dataset):
+            raise ValueError("Dataset ID must be in the format 'owner/dataset'")
+            
+        # Check if dataset exists and is accessible
+        try:
+            response = await self.client.head(f"/is-valid?dataset={dataset}")
+            response.raise_for_status()
+        except httpx.NetworkError as e:
+            raise ConnectionError(f"Network error while validating dataset: {e}")
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ValueError(f"Dataset '{dataset}' not found")
+            elif e.response.status_code == 403:
+                raise ValueError(f"Dataset '{dataset}' exists but requires authentication")
+            else:
+                raise RuntimeError(f"Error validating dataset: {e}")
+
+    async def get_info(self, dataset: str) -> dict:
+        """Get detailed information about a dataset"""
+        try:
+            # Get detailed dataset info
+            response = await self.client.get("/info", params={"dataset": dataset})
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ValueError(f"Dataset '{dataset}' not found")
+            raise
+            
+    async def get_rows(self, dataset: str, config: str, split: str, page: int = 0) -> dict:
+        """Get paginated rows of a dataset"""
         params = {
-            "dataset": dataset_id,
+            "dataset": dataset,
             "config": config,
             "split": split,
             "offset": page * 100,  # 100 rows per page
             "length": 100
         }
-            
-        response = await self.client.get(f"/rows", params=params)
+        response = await self.client.get("/rows", params=params)
         response.raise_for_status()
         return response.json()
 
-    async def get_dataset_stats(self, dataset_id: str, config: str, split: str) -> dict:
+    async def get_statistics(self, dataset: str, config: str, split: str) -> dict:
         """Get statistics about a dataset"""
-        self._validate_dataset_id(dataset_id)
-        
         params = {
-            "dataset": dataset_id,
+            "dataset": dataset,
             "config": config,
             "split": split
         }
+        response = await self.client.get("/statistics", params=params)
+        response.raise_for_status()
+        return response.json()
+        
+    async def get_first_rows(self, dataset: str, config: str, split: str) -> dict:
+        """Get first few rows of a dataset split"""
+        params = {
+            "dataset": dataset,
+            "config": config,
+            "split": split
+        }
+        response = await self.client.get("/first-rows", params=params)
+        response.raise_for_status()
+        return response.json()
+        
+    async def search(self, dataset: str, config: str, split: str, query: str) -> dict:
+        """Search for text within a dataset split"""
+        params = {
+            "dataset": dataset,
+            "config": config,
+            "split": split,
+            "query": query
+        }
+        response = await self.client.get("/search", params=params)
+        response.raise_for_status()
+        return response.json()
+
+    async def filter(self, dataset: str, config: str, split: str, where: str, orderby: str | None = None, page: int = 0) -> dict:
+        """Filter dataset rows based on conditions"""
+        # Validate page number
+        if page < 0:
+            raise ValueError("Page number must be non-negative")
             
-        response = await self.client.get(f"/statistics", params=params)
+        # Basic SQL clause validation
+        if not where.strip():
+            raise ValueError("WHERE clause cannot be empty")
+        if orderby and not orderby.strip():
+            raise ValueError("ORDER BY clause cannot be empty")
+            
+        params = {
+            "dataset": dataset,
+            "config": config,
+            "split": split,
+            "where": where,
+            "offset": page * 100,  # 100 rows per page
+            "length": 100
+        }
+        if orderby:
+            params["orderby"] = orderby
+            
+        try:
+            response = await self.client.get("/filter", params=params)
+            response.raise_for_status()
+            return response.json()
+        except httpx.NetworkError as e:
+            raise ConnectionError(f"Network error while filtering dataset: {e}")
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 400:
+                raise ValueError(f"Invalid filter query: {e.response.text}")
+            elif e.response.status_code == 404:
+                raise ValueError(f"Dataset, config or split not found: {dataset}/{config}/{split}")
+            else:
+                raise RuntimeError(f"Error filtering dataset: {e}")
+
+    async def get_parquet(self, dataset: str) -> bytes:
+        """Get entire dataset in Parquet format"""
+        response = await self.client.get("/parquet", params={"dataset": dataset})
+        response.raise_for_status()
+        return response.content
+
+    async def get_splits(self, dataset: str) -> dict:
+        """Get list of available splits for a dataset"""
+        response = await self.client.get("/splits", params={"dataset": dataset})
         response.raise_for_status()
         return response.json()
 
@@ -86,13 +168,15 @@ class DatasetState:
     def __init__(self):
         self.datasets: dict[str, dict] = {}  # Cache dataset info
         self.current_page: dict[str, int] = {}  # Track pagination
-        self.api = DatasetViewerAPI()
+        # Get auth token from environment if available
+        auth_token = os.environ.get("HUGGINGFACE_TOKEN")
+        self.api = DatasetViewerAPI(auth_token=auth_token)
 
-    async def get_dataset(self, dataset_id: str) -> dict:
+    async def get_dataset(self, dataset: str) -> dict:
         """Get dataset info, using cache if available"""
-        if dataset_id not in self.datasets:
-            self.datasets[dataset_id] = await self.api.get_dataset_info(dataset_id)
-        return self.datasets[dataset_id]
+        if dataset not in self.datasets:
+            self.datasets[dataset] = await self.api.get_info(dataset)
+        return self.datasets[dataset]
 
 
 # Initialize server and state
@@ -104,11 +188,11 @@ state = DatasetState()
 async def handle_list_resources() -> list[types.Resource]:
     """List available dataset resources"""
     resources = []
-    for dataset_id, info in state.datasets.items():
+    for dataset, info in state.datasets.items():
         resources.append(
             types.Resource(
-                uri=AnyUrl(f"dataset://{dataset_id}"),
-                name=dataset_id,
+                uri=AnyUrl(f"dataset://{dataset}"),
+                name=dataset,
                 description=info.get("description", "No description available"),
                 mimeType="application/json",
             )
@@ -122,12 +206,12 @@ async def handle_read_resource(uri: AnyUrl) -> str:
     if uri.scheme != "dataset":
         raise ValueError(f"Unsupported URI scheme: {uri.scheme}")
 
-    dataset_id = uri.path
-    if dataset_id is not None:
-        dataset_id = dataset_id.lstrip("/")
-        info = await state.get_dataset(dataset_id)
+    dataset = uri.path
+    if dataset is not None:
+        dataset = dataset.lstrip("/")
+        info = await state.get_dataset(dataset)
         return str(info)  # Convert to string for display
-    raise ValueError(f"Dataset not found: {dataset_id}")
+    raise ValueError(f"Dataset not found: {dataset}")
 
 
 @server.list_tools()
@@ -135,42 +219,241 @@ async def handle_list_tools() -> list[types.Tool]:
     """List available dataset tools for Hugging Face datasets"""
     return [
         types.Tool(
-            name="list_splits",
-            description="List available configurations and splits for a Hugging Face dataset",
+            name="get_info",
+            description="Get detailed information about a Hugging Face dataset including description, features, splits, and statistics. Run validate first to check if the dataset exists and is accessible.",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "dataset_id": {"type": "string", "description": "Dataset identifier on Hugging Face Hub (e.g. 'username/dataset-name')"},
+                    "dataset": {
+                        "type": "string",
+                        "description": "Hugging Face dataset identifier in the format owner/dataset",
+                        "pattern": "^[^/]+/[^/]+$",
+                        "examples": ["ylecun/mnist", "stanfordnlp/imdb"]
+                    },
+                    "auth_token": {
+                        "type": "string",
+                        "description": "Hugging Face auth token for private/gated datasets",
+                        "optional": True
+                    }
                 },
-                "required": ["dataset_id"],
-            },
+                "required": ["dataset"],
+            }
         ),
         types.Tool(
-            name="view_dataset",
-            description="View contents of a Hugging Face dataset with pagination",
+            name="get_rows",
+            description="Get paginated rows from a Hugging Face dataset",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "dataset_id": {"type": "string", "description": "Dataset identifier on Hugging Face Hub (e.g. 'username/dataset-name')"},
-                    "config": {"type": "string", "description": "Dataset configuration name (e.g. 'default')"},
-                    "split": {"type": "string", "description": "Dataset split name (e.g. 'train', 'test')"},
-                    "page": {"type": "integer", "description": "Page number (0-based)"},
+                    "dataset": {
+                        "type": "string",
+                        "description": "Hugging Face dataset identifier in the format owner/dataset",
+                        "pattern": "^[^/]+/[^/]+$",
+                        "examples": ["ylecun/mnist", "stanfordnlp/imdb"]
+                    },
+                    "config": {
+                        "type": "string",
+                        "description": "Dataset configuration/subset name. Use get_info to list available configs",
+                        "examples": ["default", "en", "es"]
+                    },
+                    "split": {
+                        "type": "string",
+                        "description": "Dataset split name. Splits partition the data for training/evaluation",
+                        "examples": ["train", "validation", "test"]
+                    },
+                    "page": {"type": "integer", "description": "Page number (0-based), returns 100 rows per page", "default": 0},
+                    "auth_token": {
+                        "type": "string",
+                        "description": "Hugging Face auth token for private/gated datasets",
+                        "optional": True
+                    }
                 },
-                "required": ["dataset_id", "config", "split"],
-            },
+                "required": ["dataset", "config", "split"],
+            }
         ),
         types.Tool(
-            name="get_stats",
-            description="Get statistics for a Hugging Face dataset",
+            name="get_first_rows",
+            description="Get first rows from a Hugging Face dataset split",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "dataset_id": {"type": "string", "description": "Dataset identifier on Hugging Face Hub (e.g. 'username/dataset-name')"},
-                    "config": {"type": "string", "description": "Dataset configuration name (e.g. 'default')"},
-                    "split": {"type": "string", "description": "Dataset split name (e.g. 'train', 'test')"},
+                    "dataset": {
+                        "type": "string",
+                        "description": "Hugging Face dataset identifier in the format owner/dataset",
+                        "pattern": "^[^/]+/[^/]+$",
+                        "examples": ["ylecun/mnist", "stanfordnlp/imdb"]
+                    },
+                    "config": {
+                        "type": "string",
+                        "description": "Dataset configuration/subset name. Use get_info to list available configs",
+                        "examples": ["default", "en", "es"]
+                    },
+                    "split": {
+                        "type": "string",
+                        "description": "Dataset split name. Splits partition the data for training/evaluation",
+                        "examples": ["train", "validation", "test"]
+                    },
+                    "auth_token": {
+                        "type": "string",
+                        "description": "Hugging Face auth token for private/gated datasets",
+                        "optional": True
+                    }
                 },
-                "required": ["dataset_id", "config", "split"],
-            },
+                "required": ["dataset", "config", "split"],
+            }
+        ),
+        types.Tool(
+            name="search_dataset",
+            description="Search for text within a Hugging Face dataset",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "dataset": {
+                        "type": "string",
+                        "description": "Hugging Face dataset identifier in the format owner/dataset",
+                        "pattern": "^[^/]+/[^/]+$",
+                        "examples": ["ylecun/mnist", "stanfordnlp/imdb"]
+                    },
+                    "config": {
+                        "type": "string",
+                        "description": "Dataset configuration/subset name. Use get_info to list available configs",
+                        "examples": ["default", "en", "es"]
+                    },
+                    "split": {
+                        "type": "string",
+                        "description": "Dataset split name. Splits partition the data for training/evaluation",
+                        "examples": ["train", "validation", "test"]
+                    },
+                    "query": {"type": "string", "description": "Text to search for in the dataset"},
+                    "auth_token": {
+                        "type": "string",
+                        "description": "Hugging Face auth token for private/gated datasets",
+                        "optional": True
+                    }
+                },
+                "required": ["dataset", "config", "split", "query"],
+            }
+        ),
+        types.Tool(
+            name="filter",
+            description="Filter rows in a Hugging Face dataset using SQL-like conditions",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "dataset": {
+                        "type": "string",
+                        "description": "Hugging Face dataset identifier in the format owner/dataset",
+                        "pattern": "^[^/]+/[^/]+$",
+                        "examples": ["ylecun/mnist", "stanfordnlp/imdb"]
+                    },
+                    "config": {
+                        "type": "string",
+                        "description": "Dataset configuration/subset name. Use get_info to list available configs",
+                        "examples": ["default", "en", "es"]
+                    },
+                    "split": {
+                        "type": "string",
+                        "description": "Dataset split name. Splits partition the data for training/evaluation",
+                        "examples": ["train", "validation", "test"]
+                    },
+                    "where": {
+                        "type": "string",
+                        "description": "SQL-like WHERE clause to filter rows",
+                        "examples": ["column = \"value\"", "score > 0.5", "text LIKE \"%query%\""]
+                    },
+                    "orderby": {
+                        "type": "string",
+                        "description": "SQL-like ORDER BY clause to sort results",
+                        "optional": True,
+                        "examples": ["column ASC", "score DESC", "name ASC, id DESC"]
+                    },
+                    "page": {
+                        "type": "integer",
+                        "description": "Page number for paginated results (100 rows per page)",
+                        "default": 0,
+                        "minimum": 0
+                    },
+                    "auth_token": {
+                        "type": "string",
+                        "description": "Hugging Face auth token for private/gated datasets",
+                        "optional": True
+                    }
+                },
+                "required": ["dataset", "config", "split", "where"],
+            }
+        ),
+        types.Tool(
+            name="get_statistics",
+            description="Get statistics about a Hugging Face dataset",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "dataset": {
+                        "type": "string",
+                        "description": "Hugging Face dataset identifier in the format owner/dataset",
+                        "pattern": "^[^/]+/[^/]+$",
+                        "examples": ["ylecun/mnist", "stanfordnlp/imdb"]
+                    },
+                    "config": {
+                        "type": "string",
+                        "description": "Dataset configuration/subset name. Use get_info to list available configs",
+                        "examples": ["default", "en", "es"]
+                    },
+                    "split": {
+                        "type": "string",
+                        "description": "Dataset split name. Splits partition the data for training/evaluation",
+                        "examples": ["train", "validation", "test"]
+                    },
+                    "auth_token": {
+                        "type": "string",
+                        "description": "Hugging Face auth token for private/gated datasets",
+                        "optional": True
+                    }
+                },
+                "required": ["dataset", "config", "split"],
+            }
+        ),
+        types.Tool(
+            name="get_parquet",
+            description="Export Hugging Face dataset split as Parquet file",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "dataset": {
+                        "type": "string",
+                        "description": "Hugging Face dataset identifier in the format owner/dataset",
+                        "pattern": "^[^/]+/[^/]+$",
+                        "examples": ["ylecun/mnist", "stanfordnlp/imdb"]
+                    },
+                    "auth_token": {
+                        "type": "string",
+                        "description": "Hugging Face auth token for private/gated datasets",
+                        "optional": True
+                    }
+                },
+                "required": ["dataset"],
+            }
+        ),
+        types.Tool(
+            name="validate",
+            description="Check if a Hugging Face dataset exists and is accessible",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "dataset": {
+                        "type": "string", 
+                        "description": "Hugging Face dataset identifier in the format owner/dataset",
+                        "pattern": "^[^/]+/[^/]+$",
+                        "examples": ["ylecun/mnist", "stanfordnlp/imdb"]
+                    },
+                    "auth_token": {
+                        "type": "string",
+                        "description": "Hugging Face auth token for private/gated datasets",
+                        "optional": True
+                    }
+                },
+                "required": ["dataset"],
+            }
         ),
     ]
 
@@ -183,49 +466,165 @@ async def handle_call_tool(
     if arguments is None:
         arguments = {}
 
-    if name == "list_splits":
-        dataset_id = arguments["dataset_id"]
-        info = await state.api.get_dataset_info(dataset_id)
-        return [
-            types.TextContent(
-                type="text",
-                text=f"Available splits for dataset '{dataset_id}':\n{str(info)}"
-            )
-        ]
+    # Allow overriding env token with explicit token
+    auth_token = arguments.pop("auth_token", None) or os.environ.get("HUGGINGFACE_TOKEN")
 
-    elif name == "view_dataset":
-        dataset_id = arguments["dataset_id"]
+    if name == "get_info":
+        dataset = arguments["dataset"]
+        try:
+            response = await DatasetViewerAPI(auth_token=auth_token).client.get("/info", params={"dataset": dataset})
+            response.raise_for_status()
+            result = response.json()
+            return [
+                types.TextContent(
+                    type="text",
+                    text=json.dumps(result, indent=2)
+                )
+            ]
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return [
+                    types.TextContent(
+                        type="text",
+                        text=f"Dataset '{dataset}' not found"
+                    )
+                ]
+            raise
+
+    elif name == "get_rows":
+        dataset = arguments["dataset"]
         config = arguments["config"]
         split = arguments["split"]
         page = arguments.get("page", 0)
-        
-        content = await state.api.get_dataset_content(
-            dataset_id, config=config, split=split, page=page
-        )
-        state.current_page[dataset_id] = page
-        
-        # Notify about state change
-        await server.request_context.session.send_resource_list_changed()
-        
+        rows = await DatasetViewerAPI(auth_token=auth_token).get_rows(dataset, config=config, split=split, page=page)
         return [
             types.TextContent(
                 type="text",
-                text=str(content)
+                text=json.dumps(rows, indent=2)
             )
         ]
 
-    elif name == "get_stats":
-        dataset_id = arguments["dataset_id"]
+    elif name == "get_first_rows":
+        dataset = arguments["dataset"]
         config = arguments["config"]
         split = arguments["split"]
-        stats = await state.api.get_dataset_stats(dataset_id, config=config, split=split)
+        first_rows = await DatasetViewerAPI(auth_token=auth_token).get_first_rows(dataset, config=config, split=split)
         return [
             types.TextContent(
                 type="text",
-                text=str(stats)
+                text=json.dumps(first_rows, indent=2)
             )
         ]
 
+    elif name == "search_dataset":
+        dataset = arguments["dataset"]
+        config = arguments["config"]
+        split = arguments["split"]
+        query = arguments["query"]
+        search_result = await DatasetViewerAPI(auth_token=auth_token).search(dataset, config=config, split=split, query=query)
+        return [
+            types.TextContent(
+                type="text",
+                text=json.dumps(search_result, indent=2)
+            )
+        ]
+
+    elif name == "filter":
+        dataset = arguments["dataset"]
+        config = arguments["config"]
+        split = arguments["split"]
+        where = arguments["where"]
+        orderby = arguments.get("orderby")
+        page = arguments.get("page", 0)
+        filtered = await DatasetViewerAPI(auth_token=auth_token).filter(dataset, config=config, split=split, where=where, orderby=orderby, page=page)
+        return [
+            types.TextContent(
+                type="text",
+                text=json.dumps(filtered, indent=2)
+            )
+        ]
+
+    elif name == "get_statistics":
+        dataset = arguments["dataset"]
+        config = arguments["config"]
+        split = arguments["split"]
+        stats = await DatasetViewerAPI(auth_token=auth_token).get_statistics(dataset, config=config, split=split)
+        return [
+            types.TextContent(
+                type="text",
+                text=json.dumps(stats, indent=2)
+            )
+        ]
+
+    elif name == "get_parquet":
+        dataset = arguments["dataset"]
+        parquet_data = await DatasetViewerAPI(auth_token=auth_token).get_parquet(dataset)
+        
+        # Save to a temporary file with .parquet extension
+        filename = f"{dataset.replace('/', '_')}.parquet"
+        filepath = os.path.join(os.getcwd(), filename)
+        with open(filepath, "wb") as f:
+            f.write(parquet_data)
+            
+        return [
+            types.TextContent(
+                type="text",
+                text=f"Dataset exported to: {filepath}"
+            )
+        ]
+
+    elif name == "validate":
+        dataset = arguments["dataset"]
+        try:
+            # First check format
+            if not re.match(r"^[^/]+/[^/]+$", dataset):
+                return [
+                    types.TextContent(
+                        type="text",
+                        text="Dataset must be in the format 'owner/dataset'"
+                    )
+                ]
+                
+            # Then check if dataset exists and is accessible
+            response = await DatasetViewerAPI(auth_token=auth_token).client.get("/is-valid", params={"dataset": dataset})
+            response.raise_for_status()
+            result = response.json()
+            
+            return [
+                types.TextContent(
+                    type="text",
+                    text=json.dumps(result, indent=2)
+                )
+            ]
+        except httpx.NetworkError as e:
+            return [
+                types.TextContent(
+                    type="text",
+                    text=str(e)
+                )
+            ]
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return [
+                    types.TextContent(
+                        type="text",
+                        text=f"Dataset '{dataset}' not found"
+                    )
+                ]
+            elif e.response.status_code == 403:
+                return [
+                    types.TextContent(
+                        type="text",
+                        text=f"Dataset '{dataset}' requires authentication"
+                    )
+                ]
+            else:
+                return [
+                    types.TextContent(
+                        type="text",
+                        text=str(e)
+                    )
+                ]
     raise ValueError(f"Unknown tool: {name}")
 
 
@@ -238,7 +637,7 @@ async def handle_list_prompts() -> list[types.Prompt]:
             description="Analyze a dataset's content and structure",
             arguments=[
                 types.PromptArgument(
-                    name="dataset_id",
+                    name="dataset",
                     description="Dataset identifier",
                     required=True,
                 )
@@ -254,14 +653,14 @@ async def handle_get_prompt(
     if name != "analyze-dataset":
         raise ValueError(f"Unknown prompt: {name}")
 
-    if not arguments or "dataset_id" not in arguments:
-        raise ValueError("Missing dataset_id argument")
+    if not arguments or "dataset" not in arguments:
+        raise ValueError("Missing dataset argument")
 
-    dataset_id = arguments["dataset_id"]
-    info = await state.get_dataset(dataset_id)
+    dataset = arguments["dataset"]
+    info = await state.get_dataset(dataset)
     
     return types.GetPromptResult(
-        description=f"Analyze dataset: {dataset_id}",
+        description=f"Analyze dataset: {dataset}",
         messages=[
             types.PromptMessage(
                 role="user",


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install dataset-viewer for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/dataset-viewer

Let me know if any tweaks have to be made!